### PR TITLE
feat: update gateway API manifests to v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Dependencies
 
+- update GW API version v1.1.0 → v1.2.1 (#85)
+
 ## [3.0.0] - 2025-08-23
 
 :boom: **BREAKING CHANGE** :boom:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 
 - update GW API version v1.1.0 → v1.2.1 (#85)
+  see also [GW API v1.2 upgrade notes](https://gateway-api.sigs.k8s.io/guides/#v12-upgrade-notes)
 
 ## [3.0.0] - 2025-08-23
 

--- a/talos/machine-config/control-plane.yaml.tftpl
+++ b/talos/machine-config/control-plane.yaml.tftpl
@@ -21,12 +21,8 @@ cluster:
   # cherry-picking https://github.com/vehagn/homelab/pull/78/commits
   #need to install gateway api manifests before cilium deployment. GatewayClass acceptance 
   extraManifests:
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+    - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
   inlineManifests:
   - name: cilium-values
     contents: |


### PR DESCRIPTION
update gateway API manifests from `v1.1.0` to `v1.2.1`