### PR TITLE
feat!: disallow scheduling on control plane nodes and make this adjustable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used the variable before.
   Please also see below for an additional sub-variable for governing cilium
   bootstrapping.
+- **Breaking possibly:** Do not allow scheduling of workloads on control plane
+  nodes, per default.  Also made this configurable (cf. #124).
 - Changed variable `cluster.talos_machine_config_version` (former
   `cluster.talos_version`) to be *optional* (#94, #98).
 
@@ -33,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   track k8s version.
 - Added *optional* variable `cilium_config.bootstrap_manifest_path` allowing
   usage of a custom Cilium bootstrapping manifest (#95).
+- Added *optional* variable `cluster.allow_scheduling_on_controlplane` to
+  allow scheduling of workloads on control plane nodes (#124).
 - Added *optional* variable `cluster.api_server` to define kube apiserver
   options (cf. [Talos apiServerConfig](https://www.talos.dev/v1.11/kubernetes-guides/configuration/inlinemanifests/#extramanifests)
   documentation)(#91).

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -44,6 +44,7 @@ The Kubernetes cluster configuration defines its version and network configurati
 | kubernetes_version           | **Required** Kubernetes version to set independent from Talos image inbuilt version | `string` | e.g. `"v1.33.0"`    |
 | name                         | **Required** name | `string` | e.g. `"talos"`      |
 | proxmox_cluster              | **Required** an arbitrary name for the Talos cluster<br>**will get _DEPRECATED_ in a future version** | `string` | e.g. `"proxmox"`    |
+| allow_scheduling_on_controlplane | Allow scheduling of workloads on control planes | `bool`| `false` |
 | api_server                   | Kube apiserver options (cf. [Talos apiServerConfig](https://www.talos.dev/v1.11/kubernetes-guides/configuration/inlinemanifests/#extramanifests) documentation) | `string` | `null` |
 | extraManifests               | `List` of [`extraManifests`](https://www.talos.dev/v1.11/kubernetes-guides/configuration/inlinemanifests/#extramanifests) in Talos, e.g. experimental GW API features, Flux Controller or Prometheus | `list(string)` | `[]` |
 | kubelet                      | Kubelet config values(cf. [Talos kubeletConfig](https://www.talos.dev/v1.11/reference/configuration/v1alpha1/config/#Config.machine.kubelet) | `string` | `null` |
@@ -68,6 +69,7 @@ cluster = {
   proxmox_cluster     = "homelab"
 
   # optional
+  allow_scheduling_on_controlplane = true
   api_server                   = <<-EOT
     extraArgs:
       oidc-issuer-url: "https://authelia.example.com"

--- a/talos/config.tf
+++ b/talos/config.tf
@@ -61,6 +61,7 @@ data "talos_machine_configuration" "this" {
       machine_features   = var.cluster.machine_features
     }), each.value.machine_type == "controlplane" ?
     templatefile("${path.module}/machine-config/control-plane.yaml.tftpl", {
+      allow_scheduling = var.cluster.allow_scheduling_on_controlplane
       ip               = each.value.ip
       mac_address      = try(lower(each.value.mac_address), null)
       gateway          = var.cluster.gateway

--- a/talos/machine-config/control-plane.yaml.tftpl
+++ b/talos/machine-config/control-plane.yaml.tftpl
@@ -21,7 +21,7 @@ machine:
 %{ endif }
 
 cluster:
-  allowSchedulingOnControlPlanes: true
+  allowSchedulingOnControlPlanes: ${allow_scheduling}
 %{ if api_server != null }
   apiServer:
     ${indent(4, api_server)}

--- a/talos/variables.tf
+++ b/talos/variables.tf
@@ -14,6 +14,7 @@ variable "cluster" {
     kubernetes_version           = string
     name                         = string
     proxmox_cluster              = string
+    allow_scheduling_on_controlplane = optional(bool, false)
     on_boot                      = optional(bool, true)
     subnet_mask                  = optional(string, "24")
     vip                          = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,7 @@ variable "cluster" {
     kubernetes_version           = string
     name                         = string
     proxmox_cluster              = string
+    allow_scheduling_on_controlplane = optional(bool, false)
     on_boot                      = optional(bool, true)
     subnet_mask                  = optional(string, "24")
     vip                          = optional(string)


### PR DESCRIPTION
Introduce variable `cluster.allow_scheduling_on_controlplane` (default: `false`)

**Breaking** Default behaviour changes from (hardcoded) `true` to `false`

contributes to #124