### PR TITLE
docs: prepare v5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!---
+## [Unreleased Template]
+### Changed
+### Added
+### Removed
+### Fixed
+-->
+
 ## [Unreleased]
+### Changed
+### Added
+### Removed
+### Fixed
+
+## [5.0.0] - 2025-10-03
+
+:boom: **BREAKING CHANGE** :boom:
+
 ### Changed
 
 - **Breaking:** Moved `proxmox.api_token` variable out of `promox` struct into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bootstrapping (#95).  The default paths equal the present behaviour.
 - Enabled kube-controller-manager, etcd, and kube-scheduler metrics (#116).
 - Output Talos Machine Secrets (#102).
+- Provide examples also for optional variables in the respective *Examples*
+  sections.
 
 ### Removed
 
@@ -130,6 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add optional `dns` configuration for cluster nodes (#110)
 - Add optional `on_boot` variable to control VM startup during boot (#112)
+- Created modules documentation (auto-generated) and a more elaborated documentation
+  for the variables, including examples (cf. `docs/` folder).
   
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved the way to install cilium with `inlineManifests` (#92).
 - Use `cilium-cli` image instead of `cilium-cli-ci` image to install cilium
   (#103).
 - Remove outdated `enableCiliumEndpointSlice` stanza from default cilium Helm
@@ -87,9 +88,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changing the `cluster.talos_machine_config_version` (former
   `cluster.talos_version`) variable does not destroy all VM nodes any longer
   (#38, #90).
-- Improved the way to install cilium with `inlineManifests` (#92).
 
 ### Dependencies
+
+| Component             | Version |
+| --------------------- | ------- |
+| cilium/cilium         | 1.18.2  |
+| cilium/cilium-cli     | 0.18.7  |
+| Mastercard/restapi    | 2.0.1   |
+| terraform kubernetes  | 2.38.0  |
+| terraform proxmox     | 0.82.0  |
+| terraform talos       | 0.9.0   |
 
 ## [4.0.0] - 2025-08-30
 
@@ -114,8 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schematic resource id, causing terraform/tofu to rebuild every VM at the same
   time -- without safeguarding mechanisms known from
   `update_version`/`update_schematic` (#106). 
-- Update GW API version v1.1.0 → v1.2.1 (#109)
-  see also [GW API v1.2 upgrade notes](https://gateway-api.sigs.k8s.io/guides/#v12-upgrade-notes)
+- Update GW API version v1.1.0 → v1.2.1 (#109).
+  See also [GW API v1.2 upgrade notes](https://gateway-api.sigs.k8s.io/guides/#v12-upgrade-notes)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added *optional* variable `cluster.extra_manifests` to specify
   [`extraManifests`](https://www.talos.dev/v1.11/kubernetes-guides/configuration/inlinemanifests/#extramanifests)
   in Talos (#96).
-- Added *optional* variable `cluster.kubelet` to define kubelet config values
-  (cf. [Talos kubeletConfig](https://www.talos.dev/v1.11/reference/configuration/v1alpha1/config/#Config.machine.kubelet)
-  documentation) (#97).
+- Added *optional* variable `cluster.kubelet` to define kubelet config values,
+  cf. [Talos kubeletConfig](https://www.talos.dev/v1.11/reference/configuration/v1alpha1/config/#Config.machine.kubelet)
+  documentation)(#97).
+- Added *optional* variable `cluster.machine_features` to adjust individual
+  Talos features, cf. [Talos featuresConfig](https://www.talos.dev/v1.11/reference/configuration/v1alpha1/config/#Config.machine.features)
+  documentation)(#127).
 - Added *optional* variable `cluster.subnet_mask` for defining the network 
   subnet mask (defaulting to `24`) (#86).
 - Added *optional* variable `cluster.vip` for leveraging a

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -42,8 +42,8 @@ The Kubernetes cluster configuration defines its version and network configurati
 | gateway                      | **Required** network gateway | `string` | e.g. `"10.1.2.254"` |
 | gateway_api_version          | **Required** [GW API version](https://gateway-api.sigs.k8s.io/concepts/versioning) | `string` | e.g. `"v1.2.1"` |
 | kubernetes_version           | **Required** Kubernetes version to set independent from Talos image inbuilt version | `string` | e.g. `"v1.33.0"`    |
-| name                         | **Required** name | `string` | e.g. `"talos"`      |
-| proxmox_cluster              | **Required** an arbitrary name for the Talos cluster<br>**will get _DEPRECATED_ in a future version** | `string` | e.g. `"proxmox"`    |
+| name                         | **Required** Arbitrary name of the Talos cluster | `string` | e.g. `"dev-talos"`      |
+| proxmox_cluster              | **Required** Name of the Proxmox cluster used for Promox CSI<br>will get used for `topology.kubernetes.io/region` setting | `string` | e.g. `"proxmox"`    |
 | allow_scheduling_on_controlplane | Allow scheduling of workloads on control planes | `bool`| `false` |
 | api_server                   | Kube apiserver options (cf. [Talos apiServerConfig](https://www.talos.dev/v1.11/kubernetes-guides/configuration/inlinemanifests/#extramanifests) documentation) | `string` | `null` |
 | extraManifests               | `List` of [`extraManifests`](https://www.talos.dev/v1.11/kubernetes-guides/configuration/inlinemanifests/#extramanifests) in Talos, e.g. experimental GW API features, Flux Controller or Prometheus | `list(string)` | `[]` |
@@ -65,7 +65,7 @@ cluster = {
   gateway             = "10.1.2.254"
   gateway_api_version = local.gateway_api_version
   kubernetes_version  = "v1.33.3" # renovate: github-releases=kubernetes/kubernetes
-  name                = "talos"
+  name                = "dev-talos"
   proxmox_cluster     = "homelab"
 
   # optional
@@ -138,7 +138,7 @@ The `image` parameter not only allows adjusting the downloaded Talos image by de
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------ |
 | `schematic_path` | **Required** Path to the file defining the Schematic ID for Talos image | `string` | e.g. `"assets/talos/schematic.yaml"` |
 | `version`           | **Required** [Talos version](https://github.com/siderolabs/talos/releases) with `v` prefix, e.g. `"v1.2.3"`                                                                       | `string` | e.g. `"v1.2.3"`                            |
-| `arch`              | Architecture                                                                                                                                                                      | `string` | `"amd64"` / `"arm64"`                      |
+| `arch`              | Architecture                                                                                                                                                                      | `string` | `"amd64"`                                  |
 | `factory_url`       | Alternative [Talos Factory](https://factory.talos.dev/) URL                                                                                                                       | `string` | `"https://factory.talos.dev"`              |
 | `platform`          | Typically left set to its default (`"nocloud"`), still allowing alternative configuration for [Talos platform](https://www.talos.dev/v1.10/talos-guides/install/cloud-platforms/) | `string` | `"nocloud"`                                |
 | `proxmox_datastore` | Proxmox datastore used to store the image. Please do not use a shared storage as the image is expected to be downloaded for each Proxmox node separately | `string` | `"local"`                                  |
@@ -241,7 +241,7 @@ Configuration for the connection to the Proxmox cluster, according to [bgp/terra
 
 | Key          | Description                                                                                                                                                      | Type     | Default / Example                                                      |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
-| cluster_name | **Required** name of the talos cluster<br>**will get _DEPRECATED_ in a future version**                                                                          | `string` | e.g. `"foo"`                                                           |
+| cluster_name | **Required** Name of the talos cluster                                                                                                                           | `string` | e.g. `"proxmox"`                                                           |
 | endpoint     | **Required** Proxmox endpoint to connect to                                                                                                                      | `string` | e.g. `"https://pve.example.com:8006"`                                  |
 | insecure     | **Required** Skip endpoint TLS verification if set to `true`                                                                                                     | `bool`   | e.g. `false`                                                           |
 | username     | **Required** Username for the SSH connection. A SSH connection is used to connect to the Proxmox server for operations that are not available in the Proxmox API | `string` | e.g. `"terraform"`                                                     |
@@ -250,7 +250,7 @@ Configuration for the connection to the Proxmox cluster, according to [bgp/terra
 
 ```terraform
 proxmox = {
-  cluster_name = "foo"
+  cluster_name = "proxmox"
   endpoint     = "https://pve.example.com:8006"
   insecure     = false
   username     = "terraform"


### PR DESCRIPTION
Prepare for v5 release

- removed DEPRECATED labels
- add missing documentation (e.g. `cluster.machine_features`)
- provide more examples for optional variables