### PR TITLE
fix(proxmox-csi): add missing PVE permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added missing `Sys.Audit` PVE role permission, needed by `proxmox-csi-plugin`
+  version `v0.16.0` (Helm chart version `v0.5.0`) onwards (#140)
+- Added additional PVE role permissions for supporting (zfs) replication feature
+
 ## [5.0.0] - 2025-10-03
 
 :boom: **BREAKING CHANGE** :boom:

--- a/bootstrap/proxmox-csi-plugin/config.tf
+++ b/bootstrap/proxmox-csi-plugin/config.tf
@@ -5,8 +5,17 @@ locals {
 resource "proxmox_virtual_environment_role" "csi" {
   role_id = "${local.env_prefix}CSI"
   privileges = [
+    "Sys.Audit",
     "VM.Audit",
+    "VM.Allocate",
+    "VM.Clone",
+    "VM.Config.CPU",
     "VM.Config.Disk",
+    "VM.Config.HWType",
+    "VM.Config.Memory",
+    "VM.Config.Options",
+    "VM.Migrate",
+    "VM.PowerMgmt",
     "Datastore.Allocate",
     "Datastore.AllocateSpace",
     "Datastore.Audit"


### PR DESCRIPTION
- Added missing `Sys.Audit` PVE role permission, needed by `proxmox-csi-plugin` version `v0.16.0` (Helm chart version `v0.5.0`) onwards
- Added additional PVE role permissions for supporting (zfs) replication feature

closes #140