### PR TITLE
feat: separate Terraform formatting and documentation generation

### DIFF
--- a/.github/workflows/coding-style.yaml
+++ b/.github/workflows/coding-style.yaml
@@ -1,0 +1,26 @@
+name: Fix Terraform file formatting
+on:
+  # only run on commit and not on PRs to have "style:" commit type separete from PRs
+  # pull_request: {}
+  push:
+    branches:
+      - main
+jobs:
+  formatting:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: terraform fmt
+        uses: dflook/terraform-fmt-check@10eaa13fa61437aa51be2d12fafe95f152e3512d
+        with:
+          path: .
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "docs: automated terraform docs update"
+          title: "docs: automated terraform docs update"
+          body: Update Terraform files to canonical format using `terraform fmt`
+          branch: style/automated-terraform-fmt

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,24 +1,14 @@
-name: Terraform formatting and docs generation
+name: Terraform docs generation
 on:
-  pull_request: {}
+  # only run on commit and not on PRs to not interfere with renovate PRs
+  # contributors' PRs will get updated docs when merged to main
+  # pull_request: {}
   push:
     branches:
       - main
 jobs:
-  formatting:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: terraform fmt
-        uses: dflook/terraform-fmt-check@10eaa13fa61437aa51be2d12fafe95f152e3512d
-        with:
-          path: .
   docs:
-    needs: formatting
-    runs-on: ubuntu-24.04
+    runs-on: latest
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
this helps in not interfering with renovate's PRs and fixes any formatting separate to initial PR

- `terraform fmt` not as check any longer, it will generate a PR instead --> separate commits with "feat:" and "style:"
- terraform-docs generation no on PRs --> do not interfere with renovate PRs