### PR TITLE
feat!: have uniform naming for *.datastore variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     for having a similar data usage setup as before.
   - The data_vm's disk is attached to the main Talos VM.
 
+- **Breaking:** Renamed variable `image.proxmox_datastore` to `image.datastore`
+- **Breaking:** Renamed variable `nodes.datastore_id` to `nodes.datastore`
+
 ### Added
 
 ### Removed

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -142,7 +142,7 @@ The `image` parameter not only allows adjusting the downloaded Talos image by de
 | `arch`                  | Architecture                                                                                                                                                                      | `string` | `"amd64"`                            |
 | `factory_url`           | Alternative [Talos Factory](https://factory.talos.dev/) URL                                                                                                                       | `string` | `"https://factory.talos.dev"`        |
 | `platform`              | Typically left set to its default (`"nocloud"`), still allowing alternative configuration for [Talos platform](https://www.talos.dev/v1.10/talos-guides/install/cloud-platforms/) | `string` | `"nocloud"`                          |
-| `proxmox_datastore`     | Proxmox datastore used to store the image. Please do not use a shared storage as the image is expected to be downloaded for each Proxmox node separately                          | `string` | `"local"`                            |
+| `datastore`             | Proxmox datastore used to store the image. Please do not use a shared storage as the image is expected to be downloaded for each Proxmox node separately                          | `string` | `"local"`                            |
 | `update_schematic_path` | Alternative schematic definition to be used when updating a node                                                                                                                  | `string` | `null`                               |
 | `update_version`        | Alternative version definition to be used when updating a node                                                                                                                    | `string` | `null`                               |
 
@@ -157,7 +157,7 @@ image = {
   arch                  = "arm64"
   factory_url           = "https://factory.example.com"
   platform              = "hcloud"
-  proxmox_datastore     = "local-zfs"
+  datastore             = "local-zfs"
   update_schematic_path = "assets/talos/schematic-update.yaml"
   update_version        = "v4.5.6"
 }
@@ -192,7 +192,7 @@ The `nodes` variable defines the Talos VMs that form the cluster. It consists of
 | vm_id         | **Required** Unique VM id in Proxmox cluster                                                               | `number`       | e.g. `123`                        |
 | bridge        | Network bridge the VM connect to                                                                           | `string`       | `"vmbr0"`                         |
 | cpu_type      | Proxmox [CPU type](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_cpu_type)                        | `string`       | `"x86-64-v2-AES"`                 |
-| datastore_id  | The Proxmox datastore used to store the VM                                                                 | `string`       | `"local-zfs"`                     |
+| datastore     | The Proxmox datastore used to store the VM                                                                 | `string`       | `"local-zfs"`                     |
 | disk_size     | VM disk size in GB                                                                                         | `number`       | `20`                              |
 | dns           | List of DNS servers                                                                                        | `list(string)` | `null`                            |
 | igpu          | Passthrough of an iGPU                                                                                     | `bool`         | `false`                           |
@@ -223,7 +223,7 @@ nodes = {
     # optional
     bridge        = "mybridge"
     cpu_type      = "custom-x86-64-v2-AES-AVX"
-    datastore_id  = "nfs"
+    datastore     = "nfs"
     disksize      = 30  # 30 GB
     dns           = ["1.1.1.1", "9.9.9.9"]
     igpu          = true

--- a/talos/image.tf
+++ b/talos/image.tf
@@ -55,7 +55,7 @@ resource "proxmox_virtual_environment_download_file" "this" {
 
   node_name    = each.value[0].host_node
   content_type = "iso"
-  datastore_id = var.image.proxmox_datastore
+  datastore_id = var.image.datastore
 
   # ex.: talos-ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515-v1.8.1-nocloud-amd64.img
   file_name               = "${local.env_prefix}talos-${each.value[0].schematic}-${each.value[0].version}-${var.image.platform}-${var.image.arch}.img"

--- a/talos/variables.tf
+++ b/talos/variables.tf
@@ -40,7 +40,7 @@ variable "image" {
     arch                  = optional(string, "amd64")
     factory_url           = optional(string, "https://factory.talos.dev")
     platform              = optional(string, "nocloud")
-    proxmox_datastore     = optional(string, "local")
+    datastore             = optional(string, "local")
     update_schematic_path = optional(string)
     update_version        = optional(string)
   })
@@ -58,7 +58,7 @@ variable "nodes" {
     vm_id         = number
     bridge        = optional(string, "vmbr0")
     cpu_type      = optional(string, "x86-64-v2-AES")
-    datastore_id  = optional(string, "local-zfs")
+    datastore     = optional(string, "local-zfs")
     disk_size     = optional(number, 20)
     dns           = optional(list(string))
     igpu          = optional(bool, false)

--- a/talos/virtual-machines.tf
+++ b/talos/virtual-machines.tf
@@ -34,7 +34,7 @@ resource "proxmox_virtual_environment_vm" "this" {
 
   # OS Disk
   disk {
-    datastore_id = each.value.datastore_id
+    datastore_id = each.value.datastore
     interface    = "scsi0"
     iothread     = true
     cache        = "writethrough"
@@ -72,7 +72,7 @@ resource "proxmox_virtual_environment_vm" "this" {
   }
 
   initialization {
-    datastore_id = each.value.datastore_id
+    datastore_id = each.value.datastore
 
     # Optional DNS Block.  Update Nodes with a list value to use.
     dynamic "dns" {
@@ -121,7 +121,7 @@ resource "proxmox_virtual_environment_vm" "data_vm" {
 
   # Main Disk for EPHEMERAL
   disk {
-    datastore_id = each.value.datastore_id
+    datastore_id = each.value.datastore
     interface    = "scsi0"
     iothread     = true
     cache        = "writethrough"

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "image" {
     arch                  = optional(string, "amd64")
     factory_url           = optional(string, "https://factory.talos.dev")
     platform              = optional(string, "nocloud")
-    proxmox_datastore     = optional(string, "local")
+    datastore             = optional(string, "local")
     update_schematic_path = optional(string)
     update_version        = optional(string)
   })
@@ -60,7 +60,7 @@ variable "nodes" {
     vm_id         = number
     bridge        = optional(string, "vmbr0")
     cpu_type      = optional(string, "x86-64-v2-AES")
-    datastore_id  = optional(string, "local-zfs")
+    datastore     = optional(string, "local-zfs")
     disk_size     = optional(number, 20)
     dns           = optional(list(string))
     igpu          = optional(bool, false)


### PR DESCRIPTION
BREAKING CHANGE

renamed datastore_id and proxmox_datastore in favor of datastore, i.e. do not have 3 different variable names with the same meaning

- Renamed variable `image.proxmox_datastore` to `image.datastore`
- Renamed variable `nodes.datastore_id` to `nodes.datastore`