### PR TITLE
refactor!: Renamed variable `volumes.storage` to `volumes.datastore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** Renamed variable `image.proxmox_datastore` to `image.datastore`
 - **Breaking:** Renamed variable `nodes.datastore_id` to `nodes.datastore`
+- **Breaking:** Renamed variable `volumes.storage` to `volumes.datastore`
 
 ### Added
 

--- a/bootstrap/volumes/README.md
+++ b/bootstrap/volumes/README.md
@@ -2,7 +2,7 @@
 pvesm alloc local-zfs 8000 vm-8000-app-config 1G
 ```
 
-https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{storage}/content
+https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{datastore}/content
 
 ```shell
 curl --request POST \
@@ -107,5 +107,5 @@ root@abel:~# zfs send rpool/data/<NAME>@backup | zfs receive -F -u rpool/data/<N
 ## Manually mount disk
 
 ```shell
-qm set <vmid> -<disk_type> <storage>:<volume>
+qm set <vmid> -<disk_type> <datastore>:<volume>
 ```

--- a/bootstrap/volumes/main.tf
+++ b/bootstrap/volumes/main.tf
@@ -7,12 +7,12 @@ module "proxmox-volume" {
   }
 
   volume = {
+    datastore = each.value.datastore
+    format  = each.value.format
     name    = each.key
     node    = each.value.node
     size    = each.value.size
-    storage = each.value.storage
     vmid    = each.value.vmid
-    format  = each.value.format
   }
   env = var.env
 }
@@ -26,9 +26,9 @@ module "persistent-volume" {
   }
 
   volume = {
-    name          = each.key
     capacity      = each.value.size
-    volume_handle = "${var.proxmox_api.cluster_name}/${module.proxmox-volume[each.key].node}/${module.proxmox-volume[each.key].storage}/${module.proxmox-volume[each.key].filename}"
-    storage       = each.value.storage
+    name          = each.key
+    datastore     = each.value.datastore
+    volume_handle = "${var.proxmox_api.cluster_name}/${module.proxmox-volume[each.key].node}/${module.proxmox-volume[each.key].datastore}/${module.proxmox-volume[each.key].filename}"
   }
 }

--- a/bootstrap/volumes/persistent-volume/config.tf
+++ b/bootstrap/volumes/persistent-volume/config.tf
@@ -18,7 +18,7 @@ resource "kubernetes_persistent_volume" "pv" {
         volume_attributes = {
           cache   = var.volume.cache
           ssd     = var.volume.ssd == true ? "true" : "false"
-          storage = var.volume.storage
+          storage = var.volume.datastore
         }
       }
     }

--- a/bootstrap/volumes/persistent-volume/variables.tf
+++ b/bootstrap/volumes/persistent-volume/variables.tf
@@ -10,7 +10,7 @@ variable "volume" {
     fs_type            = optional(string, "ext4")
     mount_options      = optional(list(string), ["noatime"])
     ssd                = optional(bool, true)
-    storage            = optional(string, "local-zfs")
+    datastore          = optional(string, "local-zfs")
     storage_class_name = optional(string, "proxmox-csi")
     volume_mode        = optional(string, "Filesystem")
   })

--- a/bootstrap/volumes/proxmox-volume/config.tf
+++ b/bootstrap/volumes/proxmox-volume/config.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 resource "restapi_object" "proxmox-volume" {
-  path = "/api2/json/nodes/${var.volume.node}/storage/${var.volume.storage}/content"
+  path = "/api2/json/nodes/${var.volume.node}/storage/${var.volume.datastore}/content"
 
   id_attribute = "data"
 
@@ -37,8 +37,8 @@ output "node" {
   value = var.volume.node
 }
 
-output "storage" {
-  value = var.volume.storage
+output "datastore" {
+  value = var.volume.datastore
 }
 
 output "filename" {

--- a/bootstrap/volumes/proxmox-volume/variables.tf
+++ b/bootstrap/volumes/proxmox-volume/variables.tf
@@ -6,11 +6,11 @@ variable "env" {
 
 variable "volume" {
   type = object({
+    datastore = optional(string, "local-zfs")
+    format  = optional(string, "raw")
     name    = string
     node    = string
     size    = string
-    format  = optional(string, "raw")
-    storage = optional(string, "local-zfs")
     vmid    = optional(number, 9999)
   })
 }

--- a/bootstrap/volumes/variables.tf
+++ b/bootstrap/volumes/variables.tf
@@ -15,10 +15,10 @@ variable "proxmox_api" {
 variable "volumes" {
   type = map(
     object({
+      datastore = optional(string, "local-zfs")
+      format  = optional(string, "raw")
       node    = string
       size    = string
-      format  = optional(string, "raw")
-      storage = optional(string, "local-zfs")
       vmid    = optional(number, 9999)
     })
   )

--- a/variables.tf
+++ b/variables.tf
@@ -109,8 +109,8 @@ variable "volumes" {
     object({
       node    = string
       size    = string
+      datastore = optional(string, "local-zfs")
       format  = optional(string, "raw")
-      storage = optional(string, "local-zfs")
       vmid    = optional(number, 9999)
     })
   )


### PR DESCRIPTION
missing piece in PR #153 which did not cover all `datastore` variables