### PR TITLE
fix(talos): rectify talos provider version

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -10,7 +10,7 @@ terraform {
     }
     talos = {
       source  = "siderolabs/talos"
-      version = "0.10.0"
+      version = "0.9.0"
     }
     restapi = {
       source  = "Mastercard/restapi"

--- a/talos/providers.tf
+++ b/talos/providers.tf
@@ -6,7 +6,7 @@ terraform {
     }
     talos = {
       source  = "siderolabs/talos"
-      version = ">=0.6.0"
+      version = ">=0.9.0, <0.10.0"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
This fixes 3 issues in relation to [siderolabs/terraform-provider-talos](https://redirect.github.com/siderolabs/terraform-provider-talos) provider:

1. main: pin siderolabs/talos provider to 0.9.0 version (reverting #157)
2. talos: raise dependency of siderolabs/talos provider to 0.9.0 due to #144
3. talos: constrain dependency of siderolabs/talos provider to exclude 0.10.0 due to `open : no such file or directory` issue (GH issue [terraform-provider-talos#293](https://redirect.github.com/siderolabs/terraform-provider-talos/issues/293))

waiting for 0.10.1 version to fix `open : no such file or directory` issue (implemented by PR [terraform-provider-talos#295](https://redirect.github.com/siderolabs/terraform-provider-talos/issues/295))