### PR TITLE
fix(volumes): allow volumes variable to be optional

### DIFF
--- a/bootstrap/volumes/variables.tf
+++ b/bootstrap/volumes/variables.tf
@@ -22,4 +22,5 @@ variable "volumes" {
       vmid      = optional(number, 9999)
     })
   )
+  default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -114,4 +114,5 @@ variable "volumes" {
       vmid      = optional(number, 9999)
     })
   )
+  default = {}
 }


### PR DESCRIPTION
Allow volumes variable to be optional by setting an empty map as default

Previously, the variable had to be set to `volumes = {}` manually in `terragrunt.hcl` (or `main.tf`) if now volumes should get created.  It was not sufficient commenting out an existing `volumes { ... }` block for playing around.