### PR TITLE
fix(volumes): filter on proxmox-csi volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue #177 where a `disk` type volume got interpreted as proxmox-csi volume, causing an error during `terraform plan`.
+
 ## [6.0.0] - 2026-01-19
 
 :boom: **BREAKING CHANGE** :boom:

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 module "talos" {
   source = "./talos"
 
-  # hand over volumes of type `disk`
+  # hand over volumes of type `disk` only, else an empty list
   talos_volumes = coalesce({ for k, v in var.volumes : k => v if v.type == "disk" }, {})
 
   # take over configuration from main
@@ -48,6 +48,6 @@ module "volumes" {
     kubernetes = kubernetes
   }
   proxmox_api = var.proxmox
-  volumes     = var.volumes
+  volumes     = coalesce({ for k, v in var.volumes : k => v if v.type == "proxmox-csi" }, {})
   env         = var.env
 }


### PR DESCRIPTION
- only hand over volumes of type `proxmox-csi` to module.volumes, i.e. prevent `disk` and other types

closes #177