### PR TITLE
fix(volumes): properly default datastore for disk type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue for `disk` type where `volumes[].datastore` was not properly defaulting to the VM's datastore (`nodes[].datastore`) if not specified.
+
+  See *Upgrade Note* section for further instructions.
+
+### Upgrade Note
+
+> **Important Note for `disk` Type Volumes**:
+> 
+> If you have `disk` type volumes without specifying an individual `datastore` and the VM is not using `local-zfs`, special care is required when upgrading to this version.
+
+Previously, when not specifying a specific `datastore` for `disk` type volumes, the module defaulted to `local-zfs` datastore erroneously. This is not the desired and documented behaviour (instead, the VM's datastore should be taken when no datastore is specified). As such, a module upgrade will recitify the situation by moving the disk(s) to the same datastore the VM is using.
+
+The following is required to avoid errors during `terraform plan` and `terraform apply`:
+
+
+While the disk(s) will get moved from `local-zfs` (the former datastore) to the VM's datastore without data loss, special care is required to avoid `terraform plan/apply` errors due to the dynamic behaviour of the VM disk handling logic.
+
+1. Optimally, detach the `disk` type volume(s) from the Main Talos VM(s) (not Data VMs) manually via Proxmox VE UI or CLI. See the [VM architecture documentation](docs/vms.md#separation-of-talos-vm-and-data-vm) for identifying the Main Talos VM(s).
+1. Run (`terraform plan` and) `terraform apply` _multiple_ times for getting to a final result. Terraform will produce several errors inbetween – which will get solved with multiple runs, finally.
+
+The error messages produced by `terraform` will look similar to the ones below:
+
+```
+* Failed to execute "tofu apply" in ./.terragrunt-cache/cj_qtdX4SVSN2mQL18WDg3O9M74/AXI3wB-PS_BYZEnbtpZ4j1O9g34
+  ╷
+  │ Error: Provider produced inconsistent final plan
+  │
+  │ When expanding the plan for
+  │ module.talos.proxmox_virtual_environment_vm.this["host.example.com"]
+  │ to include new values learned so far during apply, provider
+  │ "registry.opentofu.org/bpg/proxmox" produced an invalid new value for
+  │ .disk[2].path_in_datastore: was cty.StringVal("vm-1230-disk-3"), but
+  │ now cty.StringVal("vm-1230-disk-1").
+  │
+  │ This is a bug in the provider, which should be reported in the provider's
+  │ own issue tracker.
+  ╵
+
+  exit status 1
+...
+* Failed to execute "tofu apply" in ./.terragrunt-cache/cj_qtdX4SVSN2mQL18WDg3O9M74/AXI3wB-PS_BYZEnbtpZ4j1O9g34
+  ╷
+  │ Error: Defined disk interface not supported. Interface was , but only [ide sata scsi virtio] are supported
+  │
+  │   with module.talos.proxmox_virtual_environment_vm.this["host.example.com"],
+  │   on talos/virtual-machines.tf line 1, in resource "proxmox_virtual_environment_vm" "this":
+  │    1: resource "proxmox_virtual_environment_vm" "this" {
+  │
+  ╵
+
+  exit status 1
+```
+
+Should you forget to detach an additional `disk` type volume from the Main Talos VM(s) before running `terraform apply`, you will get an error message similar to the following:
+
+```
+* Failed to execute "tofu apply" in ./.terragrunt-cache/cj_qtdX4SVSN2mQL18WDg3O9M74/AXI3wB-PS_BYZEnbtpZ4j1O9g34
+  ╷
+  │ Error: Cannot move local-zfs:vm-1230-disk-1 to datastore foo in VM 123 configuration, it is not owned by this VM!
+  │
+  │   with module.talos.proxmox_virtual_environment_vm.this["host.example.com"],
+  │   on talos/virtual-machines.tf line 1, in resource "proxmox_virtual_environment_vm" "this":
+  │    1: resource "proxmox_virtual_environment_vm" "this" {
+  │
+  ╵
+
+  exit status 1
+```
+
 ## [6.0.1] - 2026-01-26
 ### Fixed
 

--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "volumes" {
       # directory, disk and partition
       machine_type = optional(string, "worker") # "all", "controlplane", "worker"
       # disk and proxmox-csi
-      datastore = optional(string, "local-zfs")
+      datastore = optional(string) # default is to use the main VM's datastore  
       # proxmox-csi only
       node   = optional(string)
       format = optional(string, "raw")


### PR DESCRIPTION
Fixed an issue for `disk` type where `volumes[].datastore` was not properly defaulting to the VM's datastore (`nodes[].datastore`) if not specified.

- remove default for variable `volumes.datastore` so it can be detected as unset and handled properly:
  - for `disk` type: use VM's datastore (already coded, though ineffective)
  - for `proxmox-csi` type: use default in volumes/variables.tf (`local-zfs`)
- FYI – Upgrade Note: If you have `disk` type volumes without specifying `datastore`, then the disk(s) will get moved from `local-zfs` to the VM's datastore without data loss.
- docs(CHANGELOG): upgrade note with multiple terraform runs