### PR TITLE
feat(talos): v1.12-compatible disk feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ If you happen to running your cluster with a `disk`-type volume, you have the fo
 
 ### Compatibility Note
 
-With this minor release, the minimum supported Talos version changed due to the new disk management features leveraged here:
+The module now supports Talos v1.12 and newer, and is incompatible with Talos v1.11 (and below).
 
 | Module/Talos Version | not using `disk` feature | using `disk` feature |
 | -------------------- | ------------------------ | -------------------- |

--- a/talos/machine-config/control-plane.yaml.tftpl
+++ b/talos/machine-config/control-plane.yaml.tftpl
@@ -49,16 +49,13 @@ cluster:
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: ${k}
-# volumeType only supported in Talos v1.12+
-# for v1.11 disabling it
-# volumeType: ${v.type}
+volumeType: ${v.type}
 provisioning:
   diskSelector:
     match: '!system_disk'
   # `disk` type does not support size-related selection as of Talos v1.12
-  # for v1.11 we can keep it, hence disabling the check
-  #{ if v.type != "disk" }
+  %{ if v.type != "disk" }
   minSize: ${v.size}
-  #{ endif }
+  %{ endif }
 %{ endif }
 %{ endfor }

--- a/talos/machine-config/worker.yaml.tftpl
+++ b/talos/machine-config/worker.yaml.tftpl
@@ -21,16 +21,13 @@ machine:
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: ${k}
-# volumeType only supported in Talos v1.12+
-# for v1.11 disabling it
-# volumeType: ${v.type}
+volumeType: ${v.type}
 provisioning:
   diskSelector:
     match: '!system_disk'
   # `disk` type does not support size-related selection as of Talos v1.12
-  # for v1.11 we can keep it, hence disabling the check
-  #{ if v.type != "disk" }
+  %{ if v.type != "disk" }
   minSize: ${v.size}
-  #{ endif }
+  %{ endif }
 %{ endif }
 %{ endfor }


### PR DESCRIPTION
Implement Talos v1.12-compatible `disk`-type volume:

- disabled `provisioning.minSize` in Talos UserVolumes document for `disk` type
- enabled `diskType` stanza (becomes necessary for differentiating between all VolumeTypes in Talos v1.12+).

pending:
- enable other volume types (#161, #162)

closes #173