### PR TITLE
fix(volumes): make disk volume more robust

### DIFF
--- a/talos/config.tf
+++ b/talos/config.tf
@@ -62,7 +62,7 @@ data "talos_machine_configuration" "this" {
       machine_features   = var.cluster.machine_features
     }), each.value.machine_type == "controlplane" ?
     templatefile("${path.module}/machine-config/control-plane.yaml.tftpl", {
-      talos_volumes    = var.talos_volumes
+      talos_disk_volumes = var.talos_disk_volumes
       allow_scheduling = var.cluster.allow_scheduling_on_controlplane
       ip               = each.value.ip
       mac_address      = try(lower(each.value.mac_address), null)
@@ -74,7 +74,7 @@ data "talos_machine_configuration" "this" {
       inline_manifests = jsonencode(terraform_data.cilium_bootstrap_inline_manifests.output)
     }) :
     templatefile("${path.module}/machine-config/worker.yaml.tftpl", {
-      talos_volumes = var.talos_volumes
+      talos_disk_volumes = var.talos_disk_volumes
       ip            = each.value.ip
       mac_address   = try(lower(each.value.mac_address), null)
       gateway       = var.cluster.gateway

--- a/talos/machine-config/control-plane.yaml.tftpl
+++ b/talos/machine-config/control-plane.yaml.tftpl
@@ -43,19 +43,18 @@ cluster:
   extraManifests: ${extra_manifests}
   inlineManifests: ${inline_manifests}
 
-%{ for k, v in talos_volumes } 
+# iterate over `disk`-type volumes
+%{ for k, v in talos_disk_volumes } 
 %{ if v.machine_type == "controlplane" || v.machine_type == "all" }
 ---
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: ${k}
-volumeType: ${v.type}
+volumeType: disk
 provisioning:
   diskSelector:
-    match: '!system_disk'
-  # `disk` type does not support size-related selection as of Talos v1.12
-  %{ if v.type != "disk" }
-  minSize: ${v.size}
-  %{ endif }
+    # https://docs.siderolabs.com/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/common#disk-selector
+    # use disk size in GB as pure number w/o UoM, as unsigned INT and append `GiB`
+    match: disk.size == ${v.size_gb}u * GiB
 %{ endif }
 %{ endfor }

--- a/talos/machine-config/worker.yaml.tftpl
+++ b/talos/machine-config/worker.yaml.tftpl
@@ -15,19 +15,18 @@ machine:
             gateway: ${gateway}
         dhcp: false
 
-%{ for k, v in talos_volumes } 
+# iterate over `disk`-type volumes
+%{ for k, v in talos_disk_volumes } 
 %{ if v.machine_type == "worker" || v.machine_type == "all" }
 ---
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: ${k}
-volumeType: ${v.type}
+volumeType: disk
 provisioning:
   diskSelector:
-    match: '!system_disk'
-  # `disk` type does not support size-related selection as of Talos v1.12
-  %{ if v.type != "disk" }
-  minSize: ${v.size}
-  %{ endif }
+    # https://docs.siderolabs.com/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/common#disk-selector
+    # use disk size in GB as pure number w/o UoM, as unsigned INT and append `GiB`
+    match: disk.size == ${v.size_gb}u * GiB
 %{ endif }
 %{ endfor }

--- a/talos/variables.tf
+++ b/talos/variables.tf
@@ -76,9 +76,33 @@ variable "talos_volumes" {
       type         = optional(string, "disk")   # "directory", "disk", "partition"
     })
   )
+  default = {}
   validation {
     // @formatter:off
     condition     = length([for i in var.talos_volumes : i if contains(["all", "controlplane", "worker"], i.machine_type)]) == length(var.talos_volumes)
+    error_message = "Volume `machine_type` must be either 'all', 'controlplane' or 'worker'."
+    // @formatter:on
+  }
+  validation {
+    // @formatter:off
+    condition     = length([for i in var.talos_volumes : i if contains(["disk", "proxmox-csi"], i.type)]) == length(var.talos_volumes)
+    error_message = "Volume `type` can be 'disk' or 'proxmox-csi' only; 'directory', 'partition' and other types not supported by this module version."
+    // @formatter:on
+  }
+}
+
+variable "talos_disk_volumes" {
+  type = map(
+    object({
+      size_gb      = number
+      datastore    = optional(string)           # default is to use the main VM's datastore
+      machine_type = optional(string, "worker") # "all", "controlplane", "worker"
+    })
+  )
+  default = {}
+  validation {
+    // @formatter:off
+    condition     = length([for i in var.talos_disk_volumes : i if contains(["all", "controlplane", "worker"], i.machine_type)]) == length(var.talos_disk_volumes)
     error_message = "Volume `machine_type` must be either 'all', 'controlplane' or 'worker'."
     // @formatter:on
   }

--- a/variables.tf
+++ b/variables.tf
@@ -124,7 +124,7 @@ variable "volumes" {
   default = {}
   validation {
     // @formatter:off
-    condition     = length([for i in var.volumes : i if contains(["directory", "disk", "partition", "proxmox-csi"], i.type)]) == length(var.volumes)
+    condition     = length([for i in var.volumes : i if contains(["disk", "proxmox-csi"], i.type)]) == length(var.volumes)
     error_message = "Volume `type` can be 'disk' or 'proxmox-csi' only; 'directory', 'partition' and other types not supported by this module version."
     // @formatter:on
   }


### PR DESCRIPTION
Tackling some drawbacks left over from #187 

- fix: implement `provisioning.diskSelector` based on disk size
- feat: introduce an internal-only used variable `talos_disk_volumes` with numeric disk size in GB (`size_gb`)
- refactor: remove dead code for not available yet `partition` and `directory` types, to be implemented properly later
- fix: disable `directory` and `partition` volume type in variables definition