### PR TITLE
feat(vm): stop VM on destroy - reincarnation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Stop VMs on destroy to avoid issues with dangling VMs in Proxmox VE when destroying the cluster with `terraform destroy` (cf. #114).
+
 ### Added
 
 ### Removed

--- a/talos/virtual-machines.tf
+++ b/talos/virtual-machines.tf
@@ -1,9 +1,8 @@
 resource "proxmox_virtual_environment_vm" "this" {
   for_each = var.nodes
 
-  node_name = each.value.host_node
-
   name        = each.key
+  node_name = each.value.host_node
   description = each.value.machine_type == "controlplane" ? "Talos Control Plane" : "Talos Worker"
   tags        = each.value.machine_type == "controlplane" ? ["k8s", "control-plane"] : ["k8s", "worker"]
   on_boot     = var.cluster.on_boot
@@ -12,6 +11,7 @@ resource "proxmox_virtual_environment_vm" "this" {
   machine       = "q35"
   scsi_hardware = "virtio-scsi-single"
   bios          = "seabios"
+  stop_on_destroy = true
 
   agent {
     enabled = true


### PR DESCRIPTION
## Purpose 

Stop VMs on destroy to avoid issues with dangling VMs in Proxmox VE when destroying the cluster with terraform destroy

closes https://github.com/isejalabs/terraform-proxmox-talos/issues/114

## Additional information

This PR got initially implemented as #202 and got re-implemented due to reverting #202 in favor of re-releaseing v6.1.0 as v7.0.0