### PR TITLE
docs: fix links after file rename

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -271,7 +271,7 @@ There's no real solution to the issue with the current implementation, as it is 
 1. When using multiple disk volumes, nevertheless, try to **add or remove only volumes whose name comes after existing volume names** in regards to their lexical order.
 1. If naming the volumes in a way that their lexical order matches the desired order of the disks in Proxmox is not possible, you need to **remove all conflicting disk volumes from the `volumes` variable**, apply the changes to remove the disks from Proxmox, and then add the conflicting disk volumes again including the desired configuration.
 
-    You need to make sure to **backup any important data** on the disks before removing them from Proxmox, as this process will lead to data loss on the respective disks. If the disks are used for a storage backend that uses replication, you can mitigate the risk of data loss by ensuring that the data is replicated to other disks before removing the disks from Proxmox and use [resource targeting](upgrading.md#resource-targeting) to apply the change to only one disk.
+   You need to make sure to **backup any important data** on the disks before removing them from Proxmox, as this process will lead to data loss on the respective disks. If the disks are used for a storage backend that uses replication, you can mitigate the risk of data loss by ensuring that the data is replicated to other disks before removing the disks from Proxmox and use [resource targeting](upgrade%20methods.md#resource-targeting) to apply the change to only one disk.
 
 ### Removing a disk volume – the need for manual handling
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -142,7 +142,7 @@ Setting the `env` variable, to e.g. `"dev"`, has an effect on the following reso
 
 ### Definition
 
-The `image` parameter not only allows adjusting the downloaded Talos image by defining its extensions (schematic), version and other settings. The two `update_` attributes allow updating to another version or schematic definition; see the [upgrade documentation](upgrading.md) for more details.
+The `image` parameter not only allows adjusting the downloaded Talos image by defining its extensions (schematic), version and other settings. The two `update_` attributes allow updating to another version or schematic definition; see the [upgrade documentation](upgrade%20methods.md#talos-os-upgrade) for more details.
 
 | Key                     | Description                                                                                                                                                                       | Type     | Default / Example                    |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------ |
@@ -152,8 +152,8 @@ The `image` parameter not only allows adjusting the downloaded Talos image by de
 | `factory_url`           | Alternative [Talos Factory](https://factory.talos.dev/) URL                                                                                                                       | `string` | `"https://factory.talos.dev"`        |
 | `platform`              | Typically left set to its default (`"nocloud"`), still allowing alternative configuration for [Talos platform](https://www.talos.dev/v1.10/talos-guides/install/cloud-platforms/) | `string` | `"nocloud"`                          |
 | `datastore`             | Proxmox datastore used to store the image. Please do not use a shared storage as the image is expected to be downloaded for each Proxmox node separately                          | `string` | `"local"`                            |
-| `update_schematic_path` | Path to an alternative schematic definition to be used when updating a node (c.f. [updating schematic documentation](upgrading.md#talos-schematic-upgrade))                                                                                                                  | `string` | `null`                               |
-| `update_version`        | Alternative version definition to be used when updating a node (c.f. [updating Talos OS version documentation](upgrading.md#talos-os-upgrade))                                                                                                                   | `string` | `null`                               |
+| `update_schematic_path` | Path to an alternative schematic definition to be used when updating a node (c.f. [updating schematic documentation](upgrade%20methods.md#talos-schematic-upgrade))               | `string` | `null`                               |
+| `update_version`        | Alternative version definition to be used when updating a node (c.f. [updating Talos OS version documentation](upgrade%20methods.md#talos-os-upgrade))                            | `string` | `null`                               |
 
 ### Example
 
@@ -206,7 +206,7 @@ The `nodes` variable defines the Talos VMs that form the cluster. It consists of
 | dns           | List of DNS servers                                                                                        | `list(string)` | `null`                            |
 | igpu          | Passthrough of an iGPU                                                                                     | `bool`         | `false`                           |
 | mac_address   | Custom MAC address, if no auto-assignment desired. Can be chosen from Proxmox' `BC:24:11` range            | `string`       | `null`                            |
-| update        | If set to `true`, the node will get updated to the [`image.update_version`](#definition-3) and/or [`image.update_schematic`](#definition-3). See the [upgrade documentation](upgrading.md#steps-to-upgrade-talos-os) for more details. | `bool`         | `false`                           |
+| update        | If set to `true`, the node will get updated to the [`image.update_version`](#definition-3) and/or [`image.update_schematic`](#definition-3). See the [upgrade documentation](upgrade%20methods.md#steps-to-upgrade-talos-os) for more details. | `bool`         | `false`                           |
 | vlan_id       | Network VLAN ID                                                                                            | `number`       | `0`                               |
 
 ### Example

--- a/docs/vms.md
+++ b/docs/vms.md
@@ -16,7 +16,7 @@ Some configuration changes (e.g. changing count of CPU cores or amount of memory
 
 ### Cluster Upgrades
 
-A special case is upgrading the cluster and its nodes which is [documented here](upgrading.md).
+A special case is upgrading the cluster and its nodes which is [documented here](upgrade%20methods.md).
 
 ## Separation of Talos VM and Data VM
 


### PR DESCRIPTION
fix some lnks

278694f81f5a9fb585aff2fbce7106347b784a94 left some links unchanged, which got rectified now – besides 984d2fddb61311eced66d200e80b31e1c8ad7f16