### PR TITLE
fix: cilium_config path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Alongside this [CHANGELOG.md](CHANGELOG.md), please consult the [UPGRADE.md](UPG
 
 ### Fixed
 
+- Fixed an issue where the path specified in `cilium_config.bootstrap_manifest_path` and `cilium_config.values_file_path` variables was based on this module's root path instead of the path the module is called from.
+
 ## [7.2.2] - 2026-04-11
 
 This quality of life release is fixing an issue with the `csi-proxmox` namespace spilling warning messages for pod security despite of the `privileged` label.

--- a/talos/config.tf
+++ b/talos/config.tf
@@ -26,7 +26,7 @@ resource "terraform_data" "cilium_bootstrap_inline_manifests" {
   input = [
     {
       name     = "cilium-bootstrap"
-      contents = file("${path.root}/${var.cilium_config.bootstrap_manifest_path}")
+      contents = file("${var.cilium_config.bootstrap_manifest_path}")
     },
     {
       name = "cilium-values"
@@ -38,7 +38,7 @@ resource "terraform_data" "cilium_bootstrap_inline_manifests" {
           namespace = "kube-system"
         }
         data = {
-          "values.yaml" = file("${path.root}/${var.cilium_config.values_file_path}")
+          "values.yaml" = file("${var.cilium_config.values_file_path}")
         }
       })
     }


### PR DESCRIPTION
Fixed an issue where the path specified in `cilium_config.bootstrap_manifest_path` and `cilium_config.values_file_path` variables was based on this module's root path instead of the path the module is called from.